### PR TITLE
WIP Optionally refresh the cache each time a page is scraped

### DIFF
--- a/lib/scraped_page_archive.rb
+++ b/lib/scraped_page_archive.rb
@@ -1,4 +1,6 @@
 require 'singleton'
+require 'fileutils'
+require 'digest/sha1'
 require 'open-uri/cached'
 
 require 'scraped_page_archive/version'
@@ -18,6 +20,11 @@ module ScrapedPageArchive
       clone_repo_if_missing!
       Dir.chdir(archive_directory) do
         create_or_checkout_archive_branch!
+        if refresh_cache?
+          cache_file = Digest::SHA1.hexdigest(url)
+          meta_file = "#{filename}.meta"
+          FileUtils.rm([cache_file, meta_file])
+        end
         OpenURI::Cache.cache_path = archive_directory
         response = yield(url)
         message = "#{response.status.join(' ')} #{url}"


### PR DESCRIPTION
⚠️  This hasn't been properly tested.

Every time a page is scraped we want to check for a new version. We do
this in a slightly hacky way by just removing open-uri-cached's version
of the page so that it recreates it then commit any changes to the html.

Fixes #1 