### PR TITLE
Make open-uri hooks optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,25 @@ You can also set this to any value (including another environment variable of yo
 ScrapedPageArchive.github_repo_url = 'https://githubtokenhere@github.com/tmtmtmtm/estonia-riigikogu'
 ```
 
+Then you can record http requests by performing them in a block passed to `ScrapedPageArchive.record`:
+
+```ruby
+ScrapedPageArchive.record do
+  response = open('http://example.com/')
+  # Use the response...
+end
+```
+
+### Use with open-uri
+
+If you would like to have your http requests automatically recorded when using open-uri do the following:
+
+```ruby
+require 'scraped_page_archive/open-uri'
+response = open('http://example.com/')
+# Use the response...
+```
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.

--- a/lib/scraped_page_archive.rb
+++ b/lib/scraped_page_archive.rb
@@ -1,6 +1,5 @@
 require 'scraped_page_archive/version'
 require 'vcr/archive'
-require 'open-uri'
 
 module ScrapedPageArchive
   extend self
@@ -33,15 +32,6 @@ module ScrapedPageArchive
     @git_remote_get_url_origin ||= begin
       remote_url = `git remote get-url origin`.chomp
       remote_url.empty? ? nil : remote_url
-    end
-  end
-end
-
-module OpenURI
-  class << self
-    alias __open_uri open_uri
-    def open_uri(*args, &block)
-      ScrapedPageArchive.record { __open_uri(*args, &block) }
     end
   end
 end

--- a/lib/scraped_page_archive/open-uri.rb
+++ b/lib/scraped_page_archive/open-uri.rb
@@ -1,0 +1,12 @@
+# Monkey patch open-uri to record http requests automatically.
+require 'open-uri'
+require 'scraped_page_archive'
+
+module OpenURI
+  class << self
+    alias __open_uri open_uri
+    def open_uri(*args, &block)
+      ScrapedPageArchive.record { __open_uri(*args, &block) }
+    end
+  end
+end


### PR DESCRIPTION
Move the monkey patches for `open-uri` into a separate file so that they're disabled by default.

Fixes https://github.com/everypolitician/scraped_page_archive/issues/6