### PR TITLE
Dont assume we're operating in a git repo

### DIFF
--- a/lib/scraped_page_archive.rb
+++ b/lib/scraped_page_archive.rb
@@ -79,9 +79,8 @@ module ScrapedPageArchive
   end
 
   def git_remote_get_url_origin
-    @git_remote_get_url_origin ||= begin
-      remote_url = `git remote get-url origin`.chomp
-      remote_url.empty? ? nil : remote_url
-    end
+    remote_url = `git config remote.origin.url`.chomp
+    return nil unless $?.success?
+    remote_url
   end
 end

--- a/test/scraped_page_archive_test.rb
+++ b/test/scraped_page_archive_test.rb
@@ -4,4 +4,32 @@ describe ScrapedPageArchive do
   it 'has a version number' do
     refute_nil ::ScrapedPageArchive::VERSION
   end
+
+  describe '#git_remote_get_url_origin' do
+    describe 'in a git repo' do
+      it 'returns the origin url of a git repo' do
+        with_tmp_dir do
+          remote_url = 'https://git.example.org/foo.git'
+          `git init`
+          `git remote add origin #{remote_url}`
+          assert_equal remote_url, ScrapedPageArchive.git_remote_get_url_origin
+        end
+      end
+
+      it 'returns nil if there is no origin remote' do
+        with_tmp_dir do
+          `git init`
+          assert_nil ScrapedPageArchive.git_remote_get_url_origin
+        end
+      end
+    end
+
+    describe 'no git repo' do
+      it 'returns nil' do
+        with_tmp_dir do
+          assert_nil ScrapedPageArchive.git_remote_get_url_origin
+        end
+      end
+    end
+  end
 end

--- a/test/scraped_page_archive_test.rb
+++ b/test/scraped_page_archive_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
-class ScrapedPageArchiveTest < Minitest::Test
-  def test_that_it_has_a_version_number
+describe ScrapedPageArchive do
+  it 'has a version number' do
     refute_nil ::ScrapedPageArchive::VERSION
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,3 +2,11 @@ $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'scraped_page_archive'
 
 require 'minitest/autorun'
+
+class Minitest::Spec
+  def with_tmp_dir(&block)
+    Dir.mktmpdir do |tmp_dir|
+      Dir.chdir(tmp_dir, &block)
+    end
+  end
+end


### PR DESCRIPTION
This changes the behaviour of `git_remote_get_url_origin` to return `nil` if the child process exits with a non-zero status code. I've also added some tests for this method so it doesn't break again in the future.

Fixes #10 