### PR TITLE
Set git user.name option after cloning

### DIFF
--- a/lib/scraped_page_archive.rb
+++ b/lib/scraped_page_archive.rb
@@ -60,7 +60,9 @@ module ScrapedPageArchive
   end
 
   def git
-    @git ||= Git.clone(git_url, tmpdir)
+    @git ||= Git.clone(git_url, tmpdir).tap do |g|
+      g.config('user.name', "scraped_page_archive gem #{ScrapedPageArchive::VERSION}")
+    end
   end
 
   def tmpdir


### PR DESCRIPTION
This is needed because git will refuse to commit if this isn't set.

Fixes #15 