### PR TITLE
Don't rescue commit errors with pry

### DIFF
--- a/lib/scraped_page_archive.rb
+++ b/lib/scraped_page_archive.rb
@@ -47,7 +47,7 @@ module ScrapedPageArchive
       interaction = git.chdir { YAML.load_file(f) }
       message = "#{interaction['response']['status'].values_at('code', 'message').join(' ')} #{interaction['request']['uri']}"
       git.add([f, f.sub(/\.yml$/, '.html')])
-      git.commit(message) rescue binding.pry
+      git.commit(message)
     end
     # FIXME: Auto-pushing should be optional if the user wants to manually do it at the end.
     git.push('origin', branch_name)


### PR DESCRIPTION
We don't have access to pry when the scrapers are running on morph, so
it's more useful to just print out any errors so they can be debugged.