### PR TITLE
add support for capybara poltergeist based scrapers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [0.4.0] - 2016-08-04
+
+### Features
+
+- Added support for Capybara Poltergeist driver
+
 ## [0.3.1] - 2016-07-29
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,3 +41,4 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 [0.2.0]: https://github.com/everypolitician/scraped_page_archive/compare/v0.1.0...v0.2.0
 [0.3.0]: https://github.com/everypolitician/scraped_page_archive/compare/v0.2.0...v0.3.0
 [0.3.1]: https://github.com/everypolitician/scraped_page_archive/compare/v0.3.0...v0.3.1
+[0.4.0]: https://github.com/everypolitician/scraped_page_archive/compare/v0.3.1...v0.4.0

--- a/README.md
+++ b/README.md
@@ -60,11 +60,27 @@ response = open('http://example.com/')
 # Use the response...
 ```
 
+### Use with the Capybara Poltergeist driver
+
+If you would like to have your http requests automatically recorded when using the Poltergeist driver in Capybara do the following:
+
+```ruby
+require 'scraped_page_archive/capybara'
+visit('http://example.com/')
+# Use the response...
+```
+
+It should be possible to adapt this to work with other Capybara drivers
+fairly easily.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
 To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+
+Note that this does not install Capybara or any drivers so if you want
+to work on that you will need to do that.
 
 ## Contributing
 

--- a/lib/scraped_page_archive/capybara.rb
+++ b/lib/scraped_page_archive/capybara.rb
@@ -3,8 +3,8 @@ require 'capybara/poltergeist'
 require 'scraped_page_archive'
 
 module Capybara::Poltergeist
-  class Driver
-    alias __visit visit
+  class Browser
+    alias __command command
 
     def sha_url(url)
       Digest::SHA1.hexdigest url
@@ -23,6 +23,7 @@ module Capybara::Poltergeist
     end
 
     def get_details(url)
+      status_code = page.status_code
       {
         'request' => {
           'method' => 'get', # assume this as no way to access it
@@ -30,30 +31,35 @@ module Capybara::Poltergeist
         },
         'response' => {
           'status' => {
-            'message' => page.status_code == 200 ? 'OK' : 'NOT OK',
-            'code' => page.status_code
+            'message' => status_code == 200 ? 'OK' : 'NOT OK',
+            'code' => status_code
           },
           'date' => [ page.response_headers['Date'] ]
         }
       }
     end
 
-    def save_request(url)
+    def save_request(html, details, url)
       html_path, yaml_path = get_paths(url)
 
       File.open(html_path,"w") do |f|
-        f.write(page.html)
+        f.write(html)
       end
       File.open(yaml_path,"w") do |f|
-        f.write(YAML.dump(get_details(url)))
+        f.write(YAML.dump(details))
       end
     end
 
-    def visit(url)
+    def command(name, *args)
+      result = __command(name, *args)
+      # we skip these methods because they are called a lot, don't cause the page
+      # to change and having record round them slows things down quite a bit.
+      return result if ['tag_name', 'visible', 'property', 'find', 'body', 'set_js_errors', 'current_url', 'status_code', 'response_headers'].include?(name)
+      current_url = page.current_url.to_s
       ScrapedPageArchive.record do
-        __visit(url)
-        save_request(page.current_url.to_s)
+        save_request(page.html, get_details(current_url), current_url)
       end
+      result
     end
   end
 end

--- a/lib/scraped_page_archive/capybara.rb
+++ b/lib/scraped_page_archive/capybara.rb
@@ -7,7 +7,7 @@ module Capybara::Poltergeist
     alias __visit visit
 
     def sha_url(url)
-      Digest::SHA1.hexdigest url.gsub(/_piref[\d_]+\./, '')
+      Digest::SHA1.hexdigest url
     end
 
     def base_dir_for_url(url)

--- a/lib/scraped_page_archive/capybara.rb
+++ b/lib/scraped_page_archive/capybara.rb
@@ -1,0 +1,58 @@
+# Monkey patch capybara poltergiest driver to record http requests automatically.
+require 'capybara/poltergeist'
+require 'scraped_page_archive'
+
+module Capybara::Poltergeist
+  class Driver
+    alias __visit visit
+
+    def sha_url(url)
+      Digest::SHA1.hexdigest url.gsub(/_piref[\d_]+\./, '')
+    end
+
+    def get_path(url)
+      base_dir = VCR::Archive::Persister.storage_location
+      page_url = URI(page.current_url)
+      page_url = URI(page.current_url)
+      dir = File.join(base_dir, page_url.host)
+      FileUtils.mkdir_p(dir)
+      sha = sha_url(page_url.to_s)
+      File.join(dir, sha)
+    end
+
+    def get_details
+      {
+        'request' => {
+          'method' => 'get',
+          'uri' => page.current_url.to_s
+        },
+        'response' => {
+          'status' => {
+            'message' => page.status_code == 200 ? 'OK' : 'NOT OK',
+            'code' => page.status_code
+          },
+          'date' => [ page.response_headers['Date'] ]
+        }
+      }
+    end
+
+    def visit(url)
+      ScrapedPageArchive.record do
+        __visit(url)
+
+        base_path = get_path(url)
+        html_path = base_path + '.html'
+        yaml_path = base_path + '.yml'
+
+        details = get_details()
+
+        File.open(html_path,"w") do |f|
+          f.write(page.html)
+        end
+        File.open(yaml_path,"w") do |f|
+          f.write(YAML.dump(details))
+        end
+      end
+    end
+  end
+end

--- a/lib/scraped_page_archive/version.rb
+++ b/lib/scraped_page_archive/version.rb
@@ -1,3 +1,3 @@
 class ScrapedPageArchive
-  VERSION = '0.3.1'.freeze
+  VERSION = '0.4.0'.freeze
 end


### PR DESCRIPTION
Overload the visit method of capybara to save html and yml files of the
content of visited pages. Should work in poltergiest based scrapers by
requiring `scraped_page_archive/capybara`.