### PR TITLE
Add method for getting pages back out of the archive

### DIFF
--- a/lib/scraped_page_archive.rb
+++ b/lib/scraped_page_archive.rb
@@ -63,46 +63,12 @@ class ScrapedPageArchive
   end
 
   def response_from(meta, response_body)
-    response = StringIO.new(response_body)
-    headers = Hash[meta['response']['headers'].map { |k, v| [k.downcase, v] }]
-    response.instance_variable_set(:"@meta", Hash[headers.map { |k, v| [k, v.join(',')] }])
-    response.instance_variable_set(:"@metas", headers)
-    response.instance_variable_set(:"@base_uri", meta['request']['uri'])
-    response.instance_variable_set(:"@status", meta['response']['status'].values.map(&:to_s))
-
-    def response.meta
-      @meta
+    StringIO.new(response_body).tap do |response|
+      OpenURI::Meta.init(response)
+      meta['response']['headers'].each { |k, v| response.meta_add_field(k, v) }
+      response.status = meta['response']['status'].values.map(&:to_s)
+      response.base_uri = URI.parse(meta['request']['uri'])
     end
-
-    def response.metas
-      @metas
-    end
-
-    def response.base_uri
-      URI.parse(@base_uri.to_s)
-    end
-
-    def response.content_type
-      @meta['content-type']
-    end
-
-    def response.charset
-      @meta['charset']
-    end
-
-    def response.content_encoding
-      @meta['content-encoding']
-    end
-
-    def response.last_modified
-      @meta['last-modified']
-    end
-
-    def response.status
-      @status
-    end
-
-    response
   end
 
   # TODO: This should be configurable.

--- a/lib/scraped_page_archive.rb
+++ b/lib/scraped_page_archive.rb
@@ -14,10 +14,6 @@ end
 class ScrapedPageArchive
   attr_writer :github_repo_url
 
-  def self.use_archive!
-    VCR.configuration.default_cassette_options[:record] = :once
-  end
-
   def self.record(*args, &block)
     new.record(*args, &block)
   end
@@ -58,6 +54,15 @@ class ScrapedPageArchive
     # FIXME: Auto-pushing should be optional if the user wants to manually do it at the end.
     git.push('origin', branch_name)
     ret
+  end
+
+  def open_from_archive(url, *args)
+    prev_record_setting = VCR.configuration.default_cassette_options[:record]
+    VCR.configuration.default_cassette_options[:record] = :once
+    VCR.use_cassette('') do
+      open(url, *args)
+    end
+    VCR.configuration.default_cassette_options[:record] = prev_record_setting
   end
 
   # TODO: This should be configurable.

--- a/lib/scraped_page_archive.rb
+++ b/lib/scraped_page_archive.rb
@@ -14,6 +14,10 @@ end
 class ScrapedPageArchive
   attr_writer :github_repo_url
 
+  def self.use_archive!
+    VCR.configuration.default_cassette_options[:record] = :once
+  end
+
   def self.record(*args, &block)
     new.record(*args, &block)
   end


### PR DESCRIPTION
This adds a `ScrapedPageArchive#open_from_archive` method which acts just like `open-uri` but will return pages from the archive instead of performing an actual http request. If the page doesn't exist in the archive then an error is raised.

In the future we could potentially have an option that will go and perform the live request if it's not in the archive, but for now I think it's better to fail noisily so we can see what conditions we might want to perform a live request under.

Part of #21 