### PR TITLE
Change ScrapedPageArchive to be a class

### DIFF
--- a/lib/scraped_page_archive.rb
+++ b/lib/scraped_page_archive.rb
@@ -11,10 +11,12 @@ VCR.configure do |config|
   config.allow_http_connections_when_no_cassette = true
 end
 
-module ScrapedPageArchive
-  extend self
-
+class ScrapedPageArchive
   attr_writer :github_repo_url
+
+  def self.record(*args, &block)
+    new.record(*args, &block)
+  end
 
   def record(&block)
     if github_repo_url.nil?

--- a/lib/scraped_page_archive/version.rb
+++ b/lib/scraped_page_archive/version.rb
@@ -1,3 +1,3 @@
-module ScrapedPageArchive
+class ScrapedPageArchive
   VERSION = '0.3.1'.freeze
 end

--- a/test/scraped_page_archive_test.rb
+++ b/test/scraped_page_archive_test.rb
@@ -6,20 +6,22 @@ describe ScrapedPageArchive do
   end
 
   describe '#git_remote_get_url_origin' do
+    subject { ScrapedPageArchive.new }
+
     describe 'in a git repo' do
       it 'returns the origin url of a git repo' do
         with_tmp_dir do
           remote_url = 'https://git.example.org/foo.git'
           `git init`
           `git remote add origin #{remote_url}`
-          assert_equal remote_url, ScrapedPageArchive.git_remote_get_url_origin
+          assert_equal remote_url, subject.git_remote_get_url_origin
         end
       end
 
       it 'returns nil if there is no origin remote' do
         with_tmp_dir do
           `git init`
-          assert_nil ScrapedPageArchive.git_remote_get_url_origin
+          assert_nil subject.git_remote_get_url_origin
         end
       end
     end
@@ -27,7 +29,7 @@ describe ScrapedPageArchive do
     describe 'no git repo' do
       it 'returns nil' do
         with_tmp_dir do
-          assert_nil ScrapedPageArchive.git_remote_get_url_origin
+          assert_nil subject.git_remote_get_url_origin
         end
       end
     end


### PR DESCRIPTION
This makes it more intuitive to use it in a script where you change
between reading from an archive and writing to an archive, instead of
modifying the state globally you just modify it for the instance you're
working with.

I've kept the shorthand for `ScrapedPageArchive.record`, so for the
simple case it will continue to function as before.

Part of the groundwork for #21 