### PR TITLE
Get GitHub url from environment variable first

### DIFF
--- a/lib/scraped_page_archive.rb
+++ b/lib/scraped_page_archive.rb
@@ -81,7 +81,7 @@ class ScrapedPageArchive
   end
 
   def github_repo_url
-    @github_repo_url ||= (git_remote_get_url_origin || ENV['MORPH_SCRAPER_CACHE_GITHUB_REPO_URL'])
+    @github_repo_url ||= (ENV['MORPH_SCRAPER_CACHE_GITHUB_REPO_URL'] || git_remote_get_url_origin)
   end
 
   def git_remote_get_url_origin


### PR DESCRIPTION
This change means that you can force the GitHub url to be a certain
value by setting an environment variable. This wasn't possible
previously as it would automatically use the `git remote` url and then
fallback to the environment variable.