### PR TITLE
Fix Ruby 2.0.0 compatibility

### DIFF
--- a/lib/scraped_page_archive.rb
+++ b/lib/scraped_page_archive.rb
@@ -65,7 +65,7 @@ class ScrapedPageArchive
   def response_from(meta, response_body)
     StringIO.new(response_body).tap do |response|
       OpenURI::Meta.init(response)
-      meta['response']['headers'].each { |k, v| response.meta_add_field(k, v) }
+      meta['response']['headers'].each { |k, v| response.meta_add_field(k, v.join(', ')) }
       response.status = meta['response']['status'].values.map(&:to_s)
       response.base_uri = URI.parse(meta['request']['uri'])
     end


### PR DESCRIPTION
This change uses the Ruby 2.0.0 interface for adding headers to an
open-uri response, which is to join them together with ', ' so that
they're in string format, rather than as an array.

We need to do it this way because it wasn't until Ruby 2.1 that open-uri
learned how to deal with headers that have multiple values.