### PR TITLE
Ensure storage location is set before running VCR

### DIFF
--- a/lib/scraped_page_archive.rb
+++ b/lib/scraped_page_archive.rb
@@ -26,6 +26,7 @@ class ScrapedPageArchive
         "See https://github.com/everypolitician/scraped_page_archive#usage for details."
       return block.call
     end
+    VCR::Archive::Persister.storage_location = g.dir.path
     ret = VCR.use_cassette('', &block)
 
     # NOTE: This is a workaround for a ruby-git bug.
@@ -80,7 +81,6 @@ class ScrapedPageArchive
     @git ||= Git.clone(git_url, tmpdir).tap do |g|
       g.config('user.name', "scraped_page_archive gem #{ScrapedPageArchive::VERSION}")
       g.config('user.email', "scraped_page_archive-#{ScrapedPageArchive::VERSION}@scrapers.everypolitician.org")
-      VCR::Archive::Persister.storage_location = g.dir.path
       if g.branches[branch_name] || g.branches["origin/#{branch_name}"]
         g.checkout(branch_name)
       else


### PR DESCRIPTION
This change fixes a bug where we were recording to the wrong directory
and not capturing the results correctly.

We need to configure VCR::Archive before we perform the VCR operations.
This ensures that the archive is saved to the correct directory.

Part of the fix for #30 