### PR TITLE
Update README to reorder usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,25 +19,19 @@ Or install it yourself as:
 
     $ gem install scraped_page_archive
 
+## How it works
+
+This gem clones the GitHub repository where the app using the gem lives. Then it  creates an orphan branch named `'scraped-pages-archive'` in GitHub and it commits to it on behalf of `scraped_page_archive gem CURRENT-VERSION`, storing the requests/responses made by the app.
+
+
 ## Usage
 
-First configure the github url to clone. This will need to have a GitHub token embedded in it, you can [generate a new one here](https://github.com/settings/tokens). It will need to have the `repo` permission checked.
 
-If you're using the excellent [morph.io](https://morph.io) then you can set the `MORPH_SCRAPER_CACHE_GITHUB_REPO_URL` environment variable to your git url:
+### Running locally
 
-| Name                                  | Value                                                           |
-|---------------------------------------|-----------------------------------------------------------------|
-| `MORPH_SCRAPER_CACHE_GITHUB_REPO_URL` | `https://githubtokenhere@github.com/tmtmtmtm/estonia-riigikogu` |
+#### Use with open-uri
 
-You can also set this to any value (including another environment variable of your choosing) with the following:
-
-```ruby
-ScrapedPageArchive.github_repo_url = 'https://githubtokenhere@github.com/tmtmtmtm/estonia-riigikogu'
-```
-
-### Use with open-uri
-
-If you would like to have your http requests automatically recorded when using open-uri do the following:
+If you would like to have your http requests automatically recorded when using open-uri and running your app locally, do the following:
 
 ```ruby
 require 'scraped_page_archive/open-uri'
@@ -45,7 +39,39 @@ response = open('http://example.com/')
 # Use the response...
 ```
 
-### Use with the Capybara Poltergeist driver
+### Running somewhere else
+
+If you are not running your app locally, then you need some extra configuration, like the url to your repo and an environment variable to set a GitHub access token. This is because, as opposed to running it locally, the gem won't know what repo it's running within, and it also won't have credentials to write to the repo.
+
+#### Use with third party platforms
+
+If you are using a platform to run your app (for example, Heroku), that needs an explicit url to your app, you can set it to be the URL of the Github repo you're going to write to, together with the GitHub token, using the following:
+
+```ruby
+require 'scraped_page_archive'
+ScrapedPageArchive.github_repo_url = 'https://YOUR_GITHUB_TOKEN@github.com/tmtmtmtm/estonia-riigikogu'
+# or ScrapedPageArchive.github_repo_url = ENV['FOO']
+```
+
+You can [generate a GitHub access token here](https://github.com/settings/tokens). It will  need to have the `repo` permission checked.
+
+> Remember not to share your GitHub access token. Don't include it in your code, especially if it lives in a public repo.
+
+
+#### Use with Morph
+
+If you're using the excellent [morph.io](https://morph.io), which also requires an explicit url, just set an environment variable there with the url to your repo and the GitHub token. Then you can set the `MORPH_SCRAPER_CACHE_GITHUB_REPO_URL` environment variable to your git url:
+
+| Name                                  | Value                                                           |
+|---------------------------------------|-----------------------------------------------------------------|
+| `MORPH_SCRAPER_CACHE_GITHUB_REPO_URL` | `https://YOUR_GITHUB_TOKEN@github.com/tmtmtmtm/estonia-riigikogu` |
+
+Finally, require the gem and use it. For example, if you are using `open-uri`, check out the previous section.
+
+
+### More complex scenarios
+
+#### Use with the Capybara Poltergeist driver
 
 If you would like to have your http requests automatically recorded when using the Poltergeist driver in Capybara do the following:
 
@@ -58,9 +84,9 @@ visit('http://example.com/')
 It should be possible to adapt this to work with other Capybara drivers
 fairly easily.
 
-### Use with ScrapedPageArchive.record
+#### Use with `ScrapedPageArchive.record`
 
-If you are not using open-uri or Capybara, you can record http requests by performing them in a block passed to `ScrapedPageArchive.record`:
+You can have complete control and record http requests by performing them in a block passed to `ScrapedPageArchive.record`:
 
 ```ruby
 require 'scraped_page_archive'
@@ -85,4 +111,4 @@ Bug reports and pull requests are welcome on GitHub at https://github.com/everyp
 
 ## License
 
-The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT).
+The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT)

--- a/README.md
+++ b/README.md
@@ -38,34 +38,38 @@ response = open('http://example.com/')
 As your scraper fetches any page it will also commit a copy of the
 response (and the headers), into a `scraped-pages-archive` branch.
 
-### Running somewhere else
+### Running on other platforms
 
-If you are not running your app locally, then you need some extra configuration, like the url to your repo and an environment variable to set a GitHub access token. This is because, as opposed to running it locally, the gem won't know what repo it's running within, and it also won't have credentials to write to the repo.
+If you are not running your app locally, or it can’t auto-detect the
+information it needs to be able to do the archiving, then you need to
+provide some extra configuration — specifically the url to your repo and
+a GitHub access token.
 
-#### Use with third party platforms
+[Generate a GitHub access token here](https://github.com/settings/tokens):
+it will need to have the `repo` permission checked. Then combine it with
+the details of your repo to produce a setting in the form:
 
-If you are using a platform to run your app (for example, Heroku), that needs an explicit url to your app, you can set it to be the URL of the Github repo you're going to write to, together with the GitHub token, using the following:
 
 ```ruby
-require 'scraped_page_archive'
-ScrapedPageArchive.github_repo_url = 'https://YOUR_GITHUB_TOKEN@github.com/tmtmtmtm/estonia-riigikogu'
-# or ScrapedPageArchive.github_repo_url = ENV['FOO']
+REPO = 'https://YOUR_GITHUB_TOKEN@github.com/everypolitician-scrapers/kenya-mzalendo'
+ScrapedPageArchive.github_repo_url = REPO
 ```
 
-You can [generate a GitHub access token here](https://github.com/settings/tokens). It will  need to have the `repo` permission checked.
+(Though, obviously, you’ll want your own scraper details there rather than
+`everypolitician-scrapers/kenya-mzalendo`!)
 
-> Remember not to share your GitHub access token. Don't include it in your code, especially if it lives in a public repo.
-
+IMPORTANT: Remember not to share your GitHub access token. Don’t include
+it in your code, especially if it lives in a public repo. Normal usage
+would be to set this from an environment variable.
 
 #### Use with Morph
 
-If you're using the excellent [morph.io](https://morph.io), which also requires an explicit url, just set an environment variable there with the url to your repo and the GitHub token. Then you can set the `MORPH_SCRAPER_CACHE_GITHUB_REPO_URL` environment variable to your git url:
-
-| Name                                  | Value                                                           |
-|---------------------------------------|-----------------------------------------------------------------|
-| `MORPH_SCRAPER_CACHE_GITHUB_REPO_URL` | `https://YOUR_GITHUB_TOKEN@github.com/tmtmtmtm/estonia-riigikogu` |
-
-Finally, require the gem and use it. For example, if you are using `open-uri`, check out the previous section.
+If you’re using the excellent [morph.io](https://morph.io), you can set
+your repo URL configuration in the "Secret environment variables"
+section of the scraper’s Settings page. We automatically check if
+`MORPH_SCRAPER_CACHE_GITHUB_REPO_URL` is set — there’s no need to
+explicitly set it using `ScrapedPageArchive.github_repo_url` in this
+case.
 
 
 ### More complex scenarios

--- a/README.md
+++ b/README.md
@@ -21,13 +21,7 @@ Or install it yourself as:
 
 ## Usage
 
-First require the library:
-
-```ruby
-require 'scraped_page_archive'
-```
-
-Then configure the github url to clone. This will need to have a GitHub token embedded in it, you can [generate a new one here](https://github.com/settings/tokens). It will need to have the `repo` permission checked.
+First configure the github url to clone. This will need to have a GitHub token embedded in it, you can [generate a new one here](https://github.com/settings/tokens). It will need to have the `repo` permission checked.
 
 If you're using the excellent [morph.io](https://morph.io) then you can set the `MORPH_SCRAPER_CACHE_GITHUB_REPO_URL` environment variable to your git url:
 
@@ -39,15 +33,6 @@ You can also set this to any value (including another environment variable of yo
 
 ```ruby
 ScrapedPageArchive.github_repo_url = 'https://githubtokenhere@github.com/tmtmtmtm/estonia-riigikogu'
-```
-
-Then you can record http requests by performing them in a block passed to `ScrapedPageArchive.record`:
-
-```ruby
-ScrapedPageArchive.record do
-  response = open('http://example.com/')
-  # Use the response...
-end
 ```
 
 ### Use with open-uri
@@ -72,6 +57,18 @@ visit('http://example.com/')
 
 It should be possible to adapt this to work with other Capybara drivers
 fairly easily.
+
+### Use with ScrapedPageArchive.record
+
+If you are not using open-uri or Capybara, you can record http requests by performing them in a block passed to `ScrapedPageArchive.record`:
+
+```ruby
+require 'scraped_page_archive'
+ScrapedPageArchive.record do
+  response = open('http://example.com/')
+  # Use the response...
+end
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -19,13 +19,7 @@ Or install it yourself as:
 
     $ gem install scraped_page_archive
 
-## How it works
-
-This gem clones the GitHub repository where the app using the gem lives. Then it  creates an orphan branch named `'scraped-pages-archive'` in GitHub and it commits to it on behalf of `scraped_page_archive gem CURRENT-VERSION`, storing the requests/responses made by the app.
-
-
 ## Usage
-
 
 ### Running locally
 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,18 @@ Or install it yourself as:
 
 #### Use with open-uri
 
-If you would like to have your http requests automatically recorded when using open-uri and running your app locally, do the following:
+If you’re running a scraper locally, and the library can auto-detect
+what repo it’s in, and find your credentials, all you need to do for an
+`open-uri` based scraper is add a `require` line:
 
 ```ruby
 require 'scraped_page_archive/open-uri'
 response = open('http://example.com/')
 # Use the response...
 ```
+
+As your scraper fetches any page it will also commit a copy of the
+response (and the headers), into a `scraped-pages-archive` branch.
 
 ### Running somewhere else
 


### PR DESCRIPTION
People wanting to use `open-uri` were using the `record`
block instead because they stopped reading once they
saw something that looked like what they should do, when
what they needed was much simpler. This commit reorders
the usage examples to (hopefully) avoid that.

Closes #22