### PR TITLE
Scrub GitHub access token from errors

### DIFF
--- a/lib/scraped_page_archive.rb
+++ b/lib/scraped_page_archive.rb
@@ -15,6 +15,7 @@ class ScrapedPageArchive
   class Error < StandardError; end
 
   attr_writer :github_repo_url
+  attr_writer :git
 
   def self.record(*args, &block)
     new.record(*args, &block)
@@ -45,6 +46,12 @@ class ScrapedPageArchive
     # FIXME: Auto-pushing should be optional if the user wants to manually do it at the end.
     git.push('origin', branch_name)
     ret
+  rescue Git::GitExecuteError => error
+    if ENV['SCRAPED_PAGE_ARCHIVE_GITHUB_TOKEN']
+      raise Git::GitExecuteError, error.message.gsub(ENV['SCRAPED_PAGE_ARCHIVE_GITHUB_TOKEN'], '[redacted]')
+    else
+      raise
+    end
   end
 
   def open_from_archive(url, *args)

--- a/test/scraped_page_archive_test.rb
+++ b/test/scraped_page_archive_test.rb
@@ -1,13 +1,13 @@
 require 'test_helper'
 
 describe ScrapedPageArchive do
+  subject { ScrapedPageArchive.new }
+
   it 'has a version number' do
     refute_nil ::ScrapedPageArchive::VERSION
   end
 
   describe '#git_remote_get_url_origin' do
-    subject { ScrapedPageArchive.new }
-
     describe 'in a git repo' do
       it 'returns the origin url of a git repo' do
         with_tmp_dir do
@@ -32,6 +32,27 @@ describe ScrapedPageArchive do
           assert_nil subject.git_remote_get_url_origin
         end
       end
+    end
+  end
+
+  describe '#record' do
+    class MockGit
+      def method_missing(*args, &block)
+        raise Git::GitExecuteError, "Access token: #{ENV['SCRAPED_PAGE_ARCHIVE_GITHUB_TOKEN']}"
+      end
+    end
+
+    before do
+      @old_access_token = ENV['SCRAPED_PAGE_ARCHIVE_GITHUB_TOKEN']
+      ENV['SCRAPED_PAGE_ARCHIVE_GITHUB_TOKEN'] = 'top_secret'
+      subject.git = MockGit.new
+    end
+
+    after { ENV['SCRAPED_PAGE_ARCHIVE_GITHUB_TOKEN'] = @old_access_token }
+
+    it 'scrubs access token from errors' do
+      error = ->{ subject.record }.must_raise Git::GitExecuteError
+      error.message.wont_include ENV['SCRAPED_PAGE_ARCHIVE_GITHUB_TOKEN']
     end
   end
 end


### PR DESCRIPTION
When git raises an error we want to rescue it and remove the github
access token from it before re-raising the error.

Fixes #25 
