### PR TITLE
Switch to using pry in bin/console

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -6,9 +6,5 @@ require 'scraped_page_archive'
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
 
-# (If you use this, don't forget to add pry to your Gemfile!)
-# require "pry"
-# Pry.start
-
-require 'irb'
-IRB.start
+require 'pry'
+Pry.start


### PR DESCRIPTION
We already had pry in the gemspec, I'd just forgotten to enable it in `bin/console`. This change fixes that.