### PR TITLE
Extract git operations into a separate storage class

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ the details of your repo to produce a setting in the form:
 
 ```ruby
 REPO = 'https://YOUR_GITHUB_TOKEN@github.com/everypolitician-scrapers/kenya-mzalendo'
-storage = ScrapedPageArchive::GitStorage.new
-storage.github_repo_url = REPO
+storage = ScrapedPageArchive::GitStorage.new(REPO)
 archive = ScrapedPageArchive.new(storage)
 archive.record { open('http://example.com/') }
 ```

--- a/README.md
+++ b/README.md
@@ -52,7 +52,10 @@ the details of your repo to produce a setting in the form:
 
 ```ruby
 REPO = 'https://YOUR_GITHUB_TOKEN@github.com/everypolitician-scrapers/kenya-mzalendo'
-ScrapedPageArchive.github_repo_url = REPO
+storage = ScrapedPageArchive::GitStorage.new
+storage.github_repo_url = REPO
+archive = ScrapedPageArchive.new(storage)
+archive.record { open('http://example.com/') }
 ```
 
 (Though, obviously, you’ll want your own scraper details there rather than

--- a/lib/scraped_page_archive.rb
+++ b/lib/scraped_page_archive.rb
@@ -15,41 +15,99 @@ end
 class ScrapedPageArchive
   class Error < StandardError; end
 
-  attr_writer :github_repo_url
+  class GitStorage
+    attr_writer :github_repo_url
+
+    # FIXME: This should be refactored so it doesn't have as much knowledge about
+    # the locations of files on the filesystem.
+    def save
+      # NOTE: This is a workaround for a ruby-git bug.
+      # @see https://github.com/schacon/ruby-git/issues/23
+      git.status.changed.each { git.diff.entries }
+
+      files = (git.status.changed.keys + git.status.untracked.keys)
+      return ret unless files.any?
+      # For each interaction, commit the yml and html along with the correct commit message.
+      files.select { |f| f.end_with?('.yml') }.each do |f|
+        interaction = git.chdir { YAML.load_file(f) }
+        message = "#{interaction['response']['status'].values_at('code', 'message').join(' ')} #{interaction['request']['uri']}"
+        git.add([f, f.sub(/\.yml$/, '.html')])
+        git.commit(message)
+      end
+      # FIXME: Auto-pushing should be optional if the user wants to manually do it at the end.
+      git.push('origin', branch_name)
+    end
+
+    # TODO: This should be configurable.
+    def branch_name
+      @branch_name ||= 'scraped-pages-archive'
+    end
+
+    def git
+      @git ||= Git.clone(git_url, tmpdir).tap do |g|
+        g.config('user.name', "scraped_page_archive gem #{ScrapedPageArchive::VERSION}")
+        g.config('user.email', "scraped_page_archive-#{ScrapedPageArchive::VERSION}@scrapers.everypolitician.org")
+        if g.branches[branch_name] || g.branches["origin/#{branch_name}"]
+          g.checkout(branch_name)
+        else
+          g.chdir do
+            # FIXME: It's not currently possible to create an orphan branch with ruby-git
+            # @see https://github.com/schacon/ruby-git/pull/140
+            system("git checkout --orphan #{branch_name}")
+            system('git rm --quiet -rf .')
+          end
+          g.commit('Initial commit', allow_empty: true)
+        end
+      end
+    end
+
+    def tmpdir
+      @tmpdir ||= Dir.mktmpdir
+    end
+
+    def git_url
+      @git_url ||= begin
+        url = URI.parse(github_repo_url)
+        url.password = ENV['SCRAPED_PAGE_ARCHIVE_GITHUB_TOKEN']
+        url.to_s
+      end
+    end
+
+    def github_repo_url
+      @github_repo_url ||= (ENV['MORPH_SCRAPER_CACHE_GITHUB_REPO_URL'] || git_remote_get_url_origin)
+    end
+
+    def git_remote_get_url_origin
+      remote_url = `git config remote.origin.url`.chomp
+      return nil unless $CHILD_STATUS.success?
+      remote_url
+    end
+  end
 
   def self.record(*args, &block)
-    new.record(*args, &block)
+    new(GitStorage.new).record(*args, &block)
+  end
+
+  attr_reader :storage
+
+  def initialize(storage)
+    @storage = storage
   end
 
   def record(&block)
-    if github_repo_url.nil?
+    if storage.github_repo_url.nil?
       warn "Could not determine git repo for 'scraped_page_archive' to use.\n\n" \
         'See https://github.com/everypolitician/scraped_page_archive#usage for details.'
       return yield
     end
-    VCR::Archive::Persister.storage_location = git.dir.path
+    VCR::Archive::Persister.storage_location = storage.git.dir.path
     ret = VCR.use_cassette('', &block)
-
-    # NOTE: This is a workaround for a ruby-git bug.
-    # @see https://github.com/schacon/ruby-git/issues/23
-    git.status.changed.each { git.diff.entries }
-
-    files = (git.status.changed.keys + git.status.untracked.keys)
-    return ret unless files.any?
-    # For each interaction, commit the yml and html along with the correct commit message.
-    files.select { |f| f.end_with?('.yml') }.each do |f|
-      interaction = git.chdir { YAML.load_file(f) }
-      message = "#{interaction['response']['status'].values_at('code', 'message').join(' ')} #{interaction['request']['uri']}"
-      git.add([f, f.sub(/\.yml$/, '.html')])
-      git.commit(message)
-    end
-    # FIXME: Auto-pushing should be optional if the user wants to manually do it at the end.
-    git.push('origin', branch_name)
+    storage.save
     ret
   end
 
   def open_from_archive(url)
-    git.chdir do
+    storage.git.chdir do
       filename = filename_from_url(url.to_s)
       meta = YAML.load_file(filename + '.yml') if File.exist?(filename + '.yml')
       response_body = File.read(filename + '.html') if File.exist?(filename + '.html')
@@ -71,50 +129,5 @@ class ScrapedPageArchive
       response.status = meta['response']['status'].values.map(&:to_s)
       response.base_uri = URI.parse(meta['request']['uri'])
     end
-  end
-
-  # TODO: This should be configurable.
-  def branch_name
-    @branch_name ||= 'scraped-pages-archive'
-  end
-
-  def git
-    @git ||= Git.clone(git_url, tmpdir).tap do |g|
-      g.config('user.name', "scraped_page_archive gem #{ScrapedPageArchive::VERSION}")
-      g.config('user.email', "scraped_page_archive-#{ScrapedPageArchive::VERSION}@scrapers.everypolitician.org")
-      if g.branches[branch_name] || g.branches["origin/#{branch_name}"]
-        g.checkout(branch_name)
-      else
-        g.chdir do
-          # FIXME: It's not currently possible to create an orphan branch with ruby-git
-          # @see https://github.com/schacon/ruby-git/pull/140
-          system("git checkout --orphan #{branch_name}")
-          system('git rm --quiet -rf .')
-        end
-        g.commit('Initial commit', allow_empty: true)
-      end
-    end
-  end
-
-  def tmpdir
-    @tmpdir ||= Dir.mktmpdir
-  end
-
-  def git_url
-    @git_url ||= begin
-      url = URI.parse(github_repo_url)
-      url.password = ENV['SCRAPED_PAGE_ARCHIVE_GITHUB_TOKEN']
-      url.to_s
-    end
-  end
-
-  def github_repo_url
-    @github_repo_url ||= (ENV['MORPH_SCRAPER_CACHE_GITHUB_REPO_URL'] || git_remote_get_url_origin)
-  end
-
-  def git_remote_get_url_origin
-    remote_url = `git config remote.origin.url`.chomp
-    return nil unless $CHILD_STATUS.success?
-    remote_url
   end
 end

--- a/lib/scraped_page_archive.rb
+++ b/lib/scraped_page_archive.rb
@@ -30,14 +30,14 @@ class ScrapedPageArchive
         'See https://github.com/everypolitician/scraped_page_archive#usage for details.'
       return yield
     end
-    VCR::Archive::Persister.storage_location = storage.git.dir.path
+    VCR::Archive::Persister.storage_location = storage.path
     ret = VCR.use_cassette('', &block)
     storage.save
     ret
   end
 
   def open_from_archive(url)
-    storage.git.chdir do
+    storage.chdir do
       filename = filename_from_url(url.to_s)
       meta = YAML.load_file(filename + '.yml') if File.exist?(filename + '.yml')
       response_body = File.read(filename + '.html') if File.exist?(filename + '.html')

--- a/lib/scraped_page_archive.rb
+++ b/lib/scraped_page_archive.rb
@@ -1,8 +1,7 @@
 require 'scraped_page_archive/version'
+require 'scraped_page_archive/git_storage'
 require 'vcr'
-require 'git'
 require 'vcr/archive'
-require 'English'
 
 VCR.configure do |config|
   config.hook_into :webmock
@@ -14,75 +13,6 @@ end
 
 class ScrapedPageArchive
   class Error < StandardError; end
-
-  class GitStorage
-    attr_writer :github_repo_url
-
-    # FIXME: This should be refactored so it doesn't have as much knowledge about
-    # the locations of files on the filesystem.
-    def save
-      # NOTE: This is a workaround for a ruby-git bug.
-      # @see https://github.com/schacon/ruby-git/issues/23
-      git.status.changed.each { git.diff.entries }
-
-      files = (git.status.changed.keys + git.status.untracked.keys)
-      return ret unless files.any?
-      # For each interaction, commit the yml and html along with the correct commit message.
-      files.select { |f| f.end_with?('.yml') }.each do |f|
-        interaction = git.chdir { YAML.load_file(f) }
-        message = "#{interaction['response']['status'].values_at('code', 'message').join(' ')} #{interaction['request']['uri']}"
-        git.add([f, f.sub(/\.yml$/, '.html')])
-        git.commit(message)
-      end
-      # FIXME: Auto-pushing should be optional if the user wants to manually do it at the end.
-      git.push('origin', branch_name)
-    end
-
-    # TODO: This should be configurable.
-    def branch_name
-      @branch_name ||= 'scraped-pages-archive'
-    end
-
-    def git
-      @git ||= Git.clone(git_url, tmpdir).tap do |g|
-        g.config('user.name', "scraped_page_archive gem #{ScrapedPageArchive::VERSION}")
-        g.config('user.email', "scraped_page_archive-#{ScrapedPageArchive::VERSION}@scrapers.everypolitician.org")
-        if g.branches[branch_name] || g.branches["origin/#{branch_name}"]
-          g.checkout(branch_name)
-        else
-          g.chdir do
-            # FIXME: It's not currently possible to create an orphan branch with ruby-git
-            # @see https://github.com/schacon/ruby-git/pull/140
-            system("git checkout --orphan #{branch_name}")
-            system('git rm --quiet -rf .')
-          end
-          g.commit('Initial commit', allow_empty: true)
-        end
-      end
-    end
-
-    def tmpdir
-      @tmpdir ||= Dir.mktmpdir
-    end
-
-    def git_url
-      @git_url ||= begin
-        url = URI.parse(github_repo_url)
-        url.password = ENV['SCRAPED_PAGE_ARCHIVE_GITHUB_TOKEN']
-        url.to_s
-      end
-    end
-
-    def github_repo_url
-      @github_repo_url ||= (ENV['MORPH_SCRAPER_CACHE_GITHUB_REPO_URL'] || git_remote_get_url_origin)
-    end
-
-    def git_remote_get_url_origin
-      remote_url = `git config remote.origin.url`.chomp
-      return nil unless $CHILD_STATUS.success?
-      remote_url
-    end
-  end
 
   def self.record(*args, &block)
     new(GitStorage.new).record(*args, &block)

--- a/lib/scraped_page_archive/git_storage.rb
+++ b/lib/scraped_page_archive/git_storage.rb
@@ -13,6 +13,14 @@ class ScrapedPageArchive
       )
     end
 
+    def path
+      git.dir.path
+    end
+
+    def chdir(&block)
+      git.chdir(&block)
+    end
+
     # FIXME: This should be refactored so it doesn't have as much knowledge about
     # the locations of files on the filesystem.
     def save
@@ -32,6 +40,8 @@ class ScrapedPageArchive
       # FIXME: Auto-pushing should be optional if the user wants to manually do it at the end.
       git.push('origin', branch_name)
     end
+
+    private
 
     # TODO: This should be configurable.
     def branch_name
@@ -56,16 +66,8 @@ class ScrapedPageArchive
       end
     end
 
-    def path
-      git.dir.path
-    end
-
     def tmpdir
       @tmpdir ||= Dir.mktmpdir
-    end
-
-    def chdir(&block)
-      git.chdir(&block)
     end
 
     def git_url

--- a/lib/scraped_page_archive/git_storage.rb
+++ b/lib/scraped_page_archive/git_storage.rb
@@ -1,0 +1,73 @@
+require 'git'
+require 'English'
+
+class ScrapedPageArchive
+  class GitStorage
+    attr_writer :github_repo_url
+
+    # FIXME: This should be refactored so it doesn't have as much knowledge about
+    # the locations of files on the filesystem.
+    def save
+      # NOTE: This is a workaround for a ruby-git bug.
+      # @see https://github.com/schacon/ruby-git/issues/23
+      git.status.changed.each { git.diff.entries }
+
+      files = (git.status.changed.keys + git.status.untracked.keys)
+      return ret unless files.any?
+      # For each interaction, commit the yml and html along with the correct commit message.
+      files.select { |f| f.end_with?('.yml') }.each do |f|
+        interaction = git.chdir { YAML.load_file(f) }
+        message = "#{interaction['response']['status'].values_at('code', 'message').join(' ')} #{interaction['request']['uri']}"
+        git.add([f, f.sub(/\.yml$/, '.html')])
+        git.commit(message)
+      end
+      # FIXME: Auto-pushing should be optional if the user wants to manually do it at the end.
+      git.push('origin', branch_name)
+    end
+
+    # TODO: This should be configurable.
+    def branch_name
+      @branch_name ||= 'scraped-pages-archive'
+    end
+
+    def git
+      @git ||= Git.clone(git_url, tmpdir).tap do |g|
+        g.config('user.name', "scraped_page_archive gem #{ScrapedPageArchive::VERSION}")
+        g.config('user.email', "scraped_page_archive-#{ScrapedPageArchive::VERSION}@scrapers.everypolitician.org")
+        if g.branches[branch_name] || g.branches["origin/#{branch_name}"]
+          g.checkout(branch_name)
+        else
+          g.chdir do
+            # FIXME: It's not currently possible to create an orphan branch with ruby-git
+            # @see https://github.com/schacon/ruby-git/pull/140
+            system("git checkout --orphan #{branch_name}")
+            system('git rm --quiet -rf .')
+          end
+          g.commit('Initial commit', allow_empty: true)
+        end
+      end
+    end
+
+    def tmpdir
+      @tmpdir ||= Dir.mktmpdir
+    end
+
+    def git_url
+      @git_url ||= begin
+        url = URI.parse(github_repo_url)
+        url.password = ENV['SCRAPED_PAGE_ARCHIVE_GITHUB_TOKEN']
+        url.to_s
+      end
+    end
+
+    def github_repo_url
+      @github_repo_url ||= (ENV['MORPH_SCRAPER_CACHE_GITHUB_REPO_URL'] || git_remote_get_url_origin)
+    end
+
+    def git_remote_get_url_origin
+      remote_url = `git config remote.origin.url`.chomp
+      return nil unless $CHILD_STATUS.success?
+      remote_url
+    end
+  end
+end

--- a/lib/scraped_page_archive/git_storage.rb
+++ b/lib/scraped_page_archive/git_storage.rb
@@ -3,7 +3,15 @@ require 'English'
 
 class ScrapedPageArchive
   class GitStorage
-    attr_writer :github_repo_url
+    attr_reader :github_repo_url
+
+    def initialize(github_repo_url = nil)
+      @github_repo_url = (
+        github_repo_url ||
+        ENV['MORPH_SCRAPER_CACHE_GITHUB_REPO_URL'] ||
+        git_remote_get_url_origin
+      )
+    end
 
     # FIXME: This should be refactored so it doesn't have as much knowledge about
     # the locations of files on the filesystem.
@@ -66,10 +74,6 @@ class ScrapedPageArchive
         url.password = ENV['SCRAPED_PAGE_ARCHIVE_GITHUB_TOKEN']
         url.to_s
       end
-    end
-
-    def github_repo_url
-      @github_repo_url ||= (ENV['MORPH_SCRAPER_CACHE_GITHUB_REPO_URL'] || git_remote_get_url_origin)
     end
 
     def git_remote_get_url_origin

--- a/lib/scraped_page_archive/git_storage.rb
+++ b/lib/scraped_page_archive/git_storage.rb
@@ -48,8 +48,16 @@ class ScrapedPageArchive
       end
     end
 
+    def path
+      git.dir.path
+    end
+
     def tmpdir
       @tmpdir ||= Dir.mktmpdir
+    end
+
+    def chdir(&block)
+      git.chdir(&block)
     end
 
     def git_url

--- a/test/scraped_page_archive_test.rb
+++ b/test/scraped_page_archive_test.rb
@@ -6,7 +6,7 @@ describe ScrapedPageArchive do
   end
 
   describe '#git_remote_get_url_origin' do
-    subject { ScrapedPageArchive.new }
+    subject { ScrapedPageArchive::GitStorage.new }
 
     describe 'in a git repo' do
       it 'returns the origin url of a git repo' do

--- a/test/scraped_page_archive_test.rb
+++ b/test/scraped_page_archive_test.rb
@@ -14,14 +14,14 @@ describe ScrapedPageArchive do
           remote_url = 'https://git.example.org/foo.git'
           `git init`
           `git remote add origin #{remote_url}`
-          assert_equal remote_url, subject.git_remote_get_url_origin
+          assert_equal remote_url, subject.github_repo_url
         end
       end
 
       it 'returns nil if there is no origin remote' do
         with_tmp_dir do
           `git init`
-          assert_nil subject.git_remote_get_url_origin
+          assert_nil subject.github_repo_url
         end
       end
     end
@@ -29,7 +29,7 @@ describe ScrapedPageArchive do
     describe 'no git repo' do
       it 'returns nil' do
         with_tmp_dir do
-          assert_nil subject.git_remote_get_url_origin
+          assert_nil subject.github_repo_url
         end
       end
     end


### PR DESCRIPTION
This introduces a new `GitStorage` class which is an extraction of the git parts of the `ScrapedPageArchive` class. This should make it easier to test the git parts of this gem in isolation. It also means there is looser coupling between `ScrapedPageArchive` and `git`.

This change was spurred on by https://github.com/everypolitician/scraped_page_archive/pull/40#discussion_r80220902.