### PR TITLE
Improve the error message when the repo url is wrong

### DIFF
--- a/lib/scraped_page_archive.rb
+++ b/lib/scraped_page_archive.rb
@@ -26,10 +26,10 @@ class ScrapedPageArchive
 
   def record(&block)
     if storage.github_repo_url.nil?
-      warn "The 'scraped_page_archive' gem wants to store the scraped pages in a git repo,\n\n" \
+      warn "The 'scraped_page_archive' gem wants to store the scraped pages in a git repo," \
         'but it cannot determine which git repo it should use.  See ' \
         'https://github.com/everypolitician/scraped_page_archive#usage for details of how ' \
-        'to specify the repo.'
+        "to specify the repo.\n\n"
       return yield
     end
     VCR::Archive::Persister.storage_location = storage.path

--- a/lib/scraped_page_archive.rb
+++ b/lib/scraped_page_archive.rb
@@ -26,8 +26,10 @@ class ScrapedPageArchive
 
   def record(&block)
     if storage.github_repo_url.nil?
-      warn "Could not determine git repo for 'scraped_page_archive' to use.\n\n" \
-        'See https://github.com/everypolitician/scraped_page_archive#usage for details.'
+      warn "The 'scraped_page_archive' gem wants to store the scraped pages in a git repo,\n\n" \
+        'but it cannot determine which git repo it should use.  See ' \
+        'https://github.com/everypolitician/scraped_page_archive#usage for details of how ' \
+        'to specify the repo.'
       return yield
     end
     VCR::Archive::Persister.storage_location = storage.path


### PR DESCRIPTION
When there is a problem in a morph scraper that is using the archiver, and the problem is either the morph environment variable has the wrong name or the url is wrong, the gem will print an error message that may be considered not very helpful.

This PR takes @davewhiteland 's suggestion in #45 to make it clearer.

Closes #45