### PR TITLE
Remove reference to variable that doesn't exist

### DIFF
--- a/lib/scraped_page_archive/git_storage.rb
+++ b/lib/scraped_page_archive/git_storage.rb
@@ -29,7 +29,7 @@ class ScrapedPageArchive
       git.status.changed.each { git.diff.entries }
 
       files = (git.status.changed.keys + git.status.untracked.keys)
-      return ret unless files.any?
+      return unless files.any?
       # For each interaction, commit the yml and html along with the correct commit message.
       files.select { |f| f.end_with?('.yml') }.each do |f|
         interaction = git.chdir { YAML.load_file(f) }


### PR DESCRIPTION
GitStorage was trying to reference a `ret` variable which doesn't exist,
which meant that when there were no files to commit it would raise an
exception and stop the scraper.

Fixes #48 

# Note to reviewer

I did try adding a regression test for this, but the `GitStorage` class tries to clone a repo before doing any operations on it. Trying to work around that in tests turned out to be a bit of a rabbit hole.

I think this is OK, since the plan is to try and tease bits of this repository out into separate tools which each focus on one job, at which point we can re-think how the git storage tool will work and write some tests for it as appropriate.