### PR TITLE
Produce a more helpful error if origin is an scp-style URL

### DIFF
--- a/lib/scraped_page_archive/git_storage.rb
+++ b/lib/scraped_page_archive/git_storage.rb
@@ -77,6 +77,7 @@ class ScrapedPageArchive
 
     def git_url
       @git_url ||= begin
+        return github_repo_url unless ENV.key?('SCRAPED_PAGE_ARCHIVE_GITHUB_TOKEN')
         url = URI.parse(github_repo_url)
         url.password = ENV['SCRAPED_PAGE_ARCHIVE_GITHUB_TOKEN']
         url.to_s

--- a/test/scraped_page_archive_test.rb
+++ b/test/scraped_page_archive_test.rb
@@ -47,4 +47,19 @@ describe ScrapedPageArchive do
       end
     end
   end
+
+  describe '#git_url' do
+    subject { ScrapedPageArchive::GitStorage.new }
+
+    describe 'in a git repo where origin is an scp-style "URL"' do
+      it 'works as expected' do
+        with_tmp_dir do
+          remote_url = 'git@github.com:everypolitician-scrapers/random-scraper.git'
+          `git init`
+          `git remote add origin #{remote_url}`
+          assert_equal remote_url, subject.send(:git_url)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
*Update:* I've changed this pull request message and subject to match what's in the PR now

git allows many styles of URL to specify a repository, which includes
the scp-style syntax:

  username@example.org:foo.git

... or:

  example.org:foo.git

This commit means that scraped_page_archive can support these styles
of git URL as well.
