### PR TITLE
Don't re-clone repo on each request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixes
+
+- Avoid recloning the whole repo for each request by caching the `ScrapedPageArchive` instance in the `open-uri` and `capybara` adapters.
+
 ## [0.4.1] - 2016-08-15
 
 ### Fixes

--- a/lib/scraped_page_archive/capybara.rb
+++ b/lib/scraped_page_archive/capybara.rb
@@ -54,10 +54,14 @@ module Capybara::Poltergeist
       # we skip these methods because they are called a lot, don't cause the page
       # to change and having record round them slows things down quite a bit.
       return result if %w(tag_name visible property find body set_js_errors current_url status_code response_headers).include?(name)
-      ScrapedPageArchive.record do
+      scraped_page_archive.record do
         save_request(body, get_details(current_url), current_url)
       end
       result
+    end
+
+    def scraped_page_archive
+      @scraped_page_archive ||= ScrapedPageArchive.new(ScrapedPageArchive::GitStorage.new)
     end
   end
 end

--- a/lib/scraped_page_archive/open-uri.rb
+++ b/lib/scraped_page_archive/open-uri.rb
@@ -6,7 +6,11 @@ module OpenURI
   class << self
     alias __open_uri open_uri
     def open_uri(*args, &block)
-      ScrapedPageArchive.record { __open_uri(*args, &block) }
+      scraped_page_archive.record { __open_uri(*args, &block) }
+    end
+
+    def scraped_page_archive
+      @scraped_page_archive ||= ScrapedPageArchive.new(ScrapedPageArchive::GitStorage.new)
     end
   end
 end


### PR DESCRIPTION
This makes it so we only create one instance of `ScrapedPageArchive::GitStorage` and therefore only have to clone the git repo once, rather than once _per request_.

This should give a fairly significant speed boost to existing scrapers.

Fixes #52 