### PR TITLE
Enable RubyGems deployment from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,8 @@ script:
   - bundle exec rake test
   - bundle exec rake rubocop
 cache: bundler
+deploy:
+  provider: rubygems
+  api_key: "$RUBYGEMS_API_KEY"
+  on:
+    tags: true

--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ After you've added a new feature or fixed a bug you should release the gem to ru
 #### Before releasing a new version
 
 - [ ] Is your new feature/bugfix documented in [`CHANGELOG.md`](CHANGELOG.md)?
-- [ ] Have you updated `ScrapedPage::VERSION` according to [SemVer](http://semver.org/)?
 - [ ] Have added a section for the new version in [`CHANGELOG.md`](CHANGELOG.md)?
+- [ ] Have you updated `ScrapedPage::VERSION` according to [SemVer](http://semver.org/)?
 - [ ] Are all of the changes that you want included in the release on the `master` branch?
 
 #### Releasing a new version

--- a/README.md
+++ b/README.md
@@ -110,6 +110,26 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 Note that this does not install Capybara or any drivers so if you want
 to work on that you will need to do that.
 
+### Releases
+
+After you've added a new feature or fixed a bug you should release the gem to rubygems.org.
+
+#### Before releasing a new version
+
+- [ ] Is your new feature/bugfix documented in [`CHANGELOG.md`](CHANGELOG.md)?
+- [ ] Have you updated `ScrapedPage::VERSION` according to [SemVer](http://semver.org/)?
+- [ ] Have added a section for the new version in [`CHANGELOG.md`](CHANGELOG.md)?
+- [ ] Are all of the changes that you want included in the release on the `master` branch?
+
+#### Releasing a new version
+
+If you wanted to release version `0.42.0`, for example, you would need to run the following commands:
+
+    git tag -a -m "scraped_page_archive v0.42.0" v0.42.0
+    git push origin --tags
+
+Then Travis CI will notice that you've pushed a new tag and will release the new version of the gem.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/everypolitician/scraped_page_archive.


### PR DESCRIPTION
This change means that when Travis notices a new tag that points to a commit on the `master` branch it will automatically release that tag to RubyGems as a new version. See the [Travis RubyGems Deployment docs](https://docs.travis-ci.com/user/deployment/rubygems) for more details.

This configuration uses a `$RUBYGEMS_API_KEY` variable, which I've set on Travis from the command line using the following command:

    travis env set RUBYGEMS_API_KEY insert_api_key_here

I got the API key from https://rubygems.org/profile/edit, I used an everypolitician specific RubyGems account that I created, the password is on the internal mySociety wiki.