### PR TITLE
Fix release date for v0.5.0 in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-## [0.5.0] - 2016-11-03
+## [0.5.0] - 2016-11-07
 
 ### Changes
 


### PR DESCRIPTION
This changes the release date for `v0.5.0` in `CHANGELOG.md` to today's date, which is when that version ended up getting released.

Related to #55 