### PR TITLE
Remove old release docs from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ end
 
 After checking out the repo, run `bin/setup` to install dependencies. Then, run `rake test` to run the tests. You can also run `bin/console` for an interactive prompt that will allow you to experiment.
 
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release`, which will create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+To install this gem onto your local machine, run `bundle exec rake install`.
 
 Note that this does not install Capybara or any drivers so if you want
 to work on that you will need to do that.


### PR DESCRIPTION
This remove the docs that tell your to use `rake release` to push to RubyGems. These aren't needed now that the releases are done on Travis (#56).