### PR TITLE
Check storage is valid before using it

### DIFF
--- a/lib/scraped_page_archive.rb
+++ b/lib/scraped_page_archive.rb
@@ -25,13 +25,7 @@ class ScrapedPageArchive
   end
 
   def record(&block)
-    if storage.github_repo_url.nil?
-      warn "The 'scraped_page_archive' gem wants to store the scraped pages in a git repo," \
-        'but it cannot determine which git repo it should use.  See ' \
-        'https://github.com/everypolitician/scraped_page_archive#usage for details of how ' \
-        "to specify the repo.\n\n"
-      return yield
-    end
+    return yield unless storage.valid?
     VCR::Archive::Persister.storage_location = storage.path
     ret = VCR.use_cassette('', &block)
     storage.save

--- a/lib/scraped_page_archive/git_storage.rb
+++ b/lib/scraped_page_archive/git_storage.rb
@@ -21,6 +21,15 @@ class ScrapedPageArchive
       git.chdir(&block)
     end
 
+    def valid?
+      return true unless github_repo_url.nil?
+      warn "The 'scraped_page_archive' gem wants to store the scraped pages in a git repo," \
+        'but it cannot determine which git repo it should use.  See ' \
+        'https://github.com/everypolitician/scraped_page_archive#usage for details of how ' \
+        "to specify the repo.\n\n"
+      false
+    end
+
     # FIXME: This should be refactored so it doesn't have as much knowledge about
     # the locations of files on the filesystem.
     def save


### PR DESCRIPTION
Moves the logic for checking if the storage is valid into the storage class behind a `valid?` method. Doing this means other storage adapters can specify their own valid checks.

This change is needed in order to support a local git repo adapter, where it doesn't make sense to have a `github_repo_url` attribute.

Part of https://github.com/everypolitician/scraped_page_archive/issues/54