### PR TITLE
chomp MORPH_SCRAPER_CACHE_GITHUB_REPO_URL

### DIFF
--- a/lib/scraped_page_archive/git_storage.rb
+++ b/lib/scraped_page_archive/git_storage.rb
@@ -9,7 +9,7 @@ class ScrapedPageArchive
       @github_repo_url = (
         github_repo_url ||
         environment_url ||
-        git_remote_get_url_origin
+        git_remote_origin_url
       )
     end
 
@@ -83,7 +83,7 @@ class ScrapedPageArchive
       end
     end
 
-    def git_remote_get_url_origin
+    def git_remote_origin_url
       remote_url = `git config remote.origin.url`.chomp
       return nil unless $CHILD_STATUS.success?
       remote_url

--- a/lib/scraped_page_archive/git_storage.rb
+++ b/lib/scraped_page_archive/git_storage.rb
@@ -8,7 +8,7 @@ class ScrapedPageArchive
     def initialize(github_repo_url = nil)
       @github_repo_url = (
         github_repo_url ||
-        ENV['MORPH_SCRAPER_CACHE_GITHUB_REPO_URL'] ||
+        environment_url ||
         git_remote_get_url_origin
       )
     end
@@ -42,6 +42,11 @@ class ScrapedPageArchive
     end
 
     private
+
+    def environment_url
+      return unless ENV.include? 'MORPH_SCRAPER_CACHE_GITHUB_REPO_URL'
+      ENV['MORPH_SCRAPER_CACHE_GITHUB_REPO_URL'].chomp
+    end
 
     # TODO: This should be configurable.
     def branch_name

--- a/test/scraped_page_archive_test.rb
+++ b/test/scraped_page_archive_test.rb
@@ -33,5 +33,18 @@ describe ScrapedPageArchive do
         end
       end
     end
+
+    describe 'MORPH_SCRAPER_CACHE_GITHUB_REPO_URL' do
+      let(:remote_url) { "https://github.com/everypolitician-scrapers/estonia-riigikogu\n" }
+
+      it 'chomps any supplied ENV var' do
+        with_tmp_dir do
+          original_env = ENV['MORPH_SCRAPER_CACHE_GITHUB_REPO_URL']
+          ENV['MORPH_SCRAPER_CACHE_GITHUB_REPO_URL'] = remote_url
+          assert_equal remote_url.chomp, subject.github_repo_url
+          ENV['MORPH_SCRAPER_CACHE_GITHUB_REPO_URL'] = original_env
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
Sometimes we'll accidentally create an environment variable in Morph
with a trailing new-line. To protect against that blowing up, chomp the
variable before using it.

Fixes https://github.com/everypolitician/scraped_page_archive/issues/47